### PR TITLE
Change "Ban reason" to "Default kick reason"

### DIFF
--- a/htdocs/iframes/settings.html
+++ b/htdocs/iframes/settings.html
@@ -208,7 +208,7 @@
                         <div class="clear">&nbsp;</div>
                     </div>
                     <div class="text-input">
-                        <div class="text-title">Ban reason:</div>
+                        <div class="text-title">Default kick reason:</div>
                         <div class="ipb"><input type="text" style="width:230px;" id="banreason" value="Bye"></div>
                         <div class="clear">&nbsp;</div>
                     </div>


### PR DESCRIPTION
The "Ban reason" setting should really be "Kick reason" seeing as the reason is sent with the `KICK` command and not when the ban mode is set.